### PR TITLE
Fix JSON deserialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,4 @@ serde = { version = "1.0", optional = true }
 
 [dev-dependencies]
 serde_test = "1.0"
+serde_json = "1.0"


### PR DESCRIPTION
It seems like `serde_json` serializes byte arrays in the same way as vectors, so it needs `visit_seq` implemented on the visitor to be able to deserialize it. If you try deserializing an `ArcCStr` without this it throws an `invalid type: sequence` error.