### PR TITLE
Updates to add str serde, remove atomic instructions from construction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arccstr"
-version = "1.3.0"
+version = "1.4.0"
 authors = ["Jon Gjengset <jon@thesquareplanet.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -14,6 +14,7 @@ categories = ["concurrency", "data-structures", "memory-management"]
 
 [features]
 default = ["serde"]
+serde_str = ["serde"]
 
 [badges]
 azure-devops = { project = "jonhoo/jonhoo", pipeline = "arccstr", build = "22" }


### PR DESCRIPTION
Furthermore, drops use of unwrap, reduces use of `size_of` + `align_of` to 1 time each.

Tries to reduce duplication, and also allows serde using a string where possible.